### PR TITLE
put debug output behind a flag.

### DIFF
--- a/add-node-modules-path.el
+++ b/add-node-modules-path.el
@@ -32,7 +32,13 @@
 ;;; Code:
 
 ;;;###autoload
+(defvar add-node-modules-path-debug nil
+  "Enable verbose output when non nil.")
+
+;;;###autoload
 (defun add-node-modules-path ()
+  "Search the current buffer's parent directories for `node_modules/.bin`.
+If it's found, then add it to the `exec-path'."
   (let* ((root (locate-dominating-file
                 (or (buffer-file-name) default-directory)
                 "node_modules"))
@@ -42,8 +48,10 @@
         (progn
           (make-local-variable 'exec-path)
           (add-to-list 'exec-path path)
-          (message "added node_modules to exec-path"))
-      (message "node_modules not found"))))
+          (when add-node-modules-path-debug
+            (message (concat "added " path  " to exec-path"))))
+      (when add-node-modules-path-debug
+        (message (concat "node_modules not found in " root))))))
 
 (provide 'add-node-modules-path)
 


### PR DESCRIPTION
Thank you so much for this package! I love it.

However, every time you open a javascript file, it echoes the fact that it added node_modules into the mini-buffer, which, when the package is operating as expected is mostly noise.

This enhances the debug output to not only include the exact directories which are added to the `exec-path`, but also to only output when the debug flag, `add-node-modules-path-debug` is turned on.