### PR TITLE
Remove verbose description about `js2-mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,4 @@ To automatically run it when opening a new buffer:
 ```
 (eval-after-load 'js-mode
   '(add-hook 'js-mode-hook #'add-node-modules-path))
-
-(eval-after-load 'js2-mode
-  '(add-hook 'js2-mode-hook #'add-node-modules-path))
 ```


### PR DESCRIPTION
> `js2-mode` now derives from `js-mode`. That means the former function will run `js-mode-hook`, as well as `js2-mode-hook`.

Please see <https://github.com/mooz/js2-mode/blob/5cb52a7de8218bb2d50f67ba422fa7b2d51d1dc6/NEWS.md#20150909>.