### PR TITLE
:bug: check for buffer-file-name. Expand default-dir.

### DIFF
--- a/add-node-modules-path.el
+++ b/add-node-modules-path.el
@@ -48,10 +48,11 @@ Traverse the directory structure up, until reaching the user's home directory,
  or hitting add-node-modules-max-depth.
 Any path found is added to the `exec-path'."
   (interactive)
-  (let* ((file (or (buffer-file-name) (expand-file-name default-directory)))
+  (let* ((default-dir (expand-file-name default-directory))
+         (file (or (buffer-file-name) default-dir))
          (home (expand-file-name "~"))
          (iterations add-node-modules-max-depth)
-         (root (directory-file-name (or (and (buffer-file-name) (file-name-directory (buffer-file-name))) (expand-file-name default-directory))))
+         (root (directory-file-name (or (and (buffer-file-name) (file-name-directory (buffer-file-name))) default-dir)))
          (roots '()))
     (while (and root (> iterations 0))
       (setq iterations (1- iterations))

--- a/add-node-modules-path.el
+++ b/add-node-modules-path.el
@@ -48,10 +48,10 @@ Traverse the directory structure up, until reaching the user's home directory,
  or hitting add-node-modules-max-depth.
 Any path found is added to the `exec-path'."
   (interactive)
-  (let* ((file (or (buffer-file-name) default-directory))
+  (let* ((file (or (buffer-file-name) (expand-file-name default-directory)))
          (home (expand-file-name "~"))
          (iterations add-node-modules-max-depth)
-         (root (directory-file-name (or (file-name-directory (buffer-file-name)) default-directory)))
+         (root (directory-file-name (or (and (buffer-file-name) (file-name-directory (buffer-file-name))) (expand-file-name default-directory))))
          (roots '()))
     (while (and root (> iterations 0))
       (setq iterations (1- iterations))


### PR DESCRIPTION
Since we set home to the expanded-file-name, we need to do the same
for default-directory.

I ran into this issue when creating a buffer with json-mode (ex: 'test.json').  Since it didn't have a buffer-file-name, it would use default-directory, which doesn't expand "~".