### PR TITLE
Feature/20 monorepo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ To automatically run it when opening a new buffer:
 (eval-after-load 'js-mode
   '(add-hook 'js-mode-hook #'add-node-modules-path))
 ```
+
+## Monorepo Support
+In a monorepo scenario it might make sense to add multiple directories.
+To achieve this, a comma-separated list of commands can be specified:
+
+```
+(use-package add-node-modules-path
+  :custom
+  (add-node-modules-path-command "pnpm bin, pnpm bin -w")) 
+```

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ To automatically run it when opening a new buffer:
 
 ## Monorepo Support
 In a monorepo scenario it might make sense to add multiple directories.
-To achieve this, a comma-separated list of commands can be specified:
+To achieve this, additional commands can be specified:
 
 ```
 (use-package add-node-modules-path
   :custom
-  (add-node-modules-path-command "pnpm bin, pnpm bin -w")) 
+  (add-node-modules-path-command '("pnpm bin" "pnpm bin -w"))) 
 ```

--- a/test/add-node-modules-path-test.el
+++ b/test/add-node-modules-path-test.el
@@ -56,3 +56,56 @@
       (should (eq (add-node-modules-path/get-invalid-executions elt) nil)))
     (dolist (elt test-data)
       (should (equal (add-node-modules-path/get-invalid-executions (car elt)) (cadr elt))))))
+
+(ert-deftest add-node-modules-path-single-command-test ()
+  ;; remove any local binding of EXEC-PATH, if present
+  (kill-local-variable 'exec-path)
+  ;; prepare environment
+  (make-local-variable 'add-node-modules-path-debug)
+  (setq add-node-modules-path-debug nil)
+  (make-local-variable 'add-node-modules-path-command)
+  (setq add-node-modules-path-command "echo \"/etc\"")
+  ;; run interactive command, which will create local binding of EXEC-PATH and add to it
+  (add-node-modules-path)
+  ;; checks
+  (should (eq (local-variable-p 'exec-path) t))
+  (should (equal (car exec-path) "/etc"))
+  ;; env cleanup
+  (kill-local-variable 'add-node-modules-path-debug)
+  (kill-local-variable 'add-node-modules-path-command))
+  
+(ert-deftest add-node-modules-path-multiple-commands-test ()
+  ;; remove any local binding of EXEC-PATH, if present
+  (kill-local-variable 'exec-path)
+  ;; prepare environment
+  (make-local-variable 'add-node-modules-path-debug)
+  (setq add-node-modules-path-debug nil)
+  (make-local-variable 'add-node-modules-path-command)
+  (setq add-node-modules-path-command "echo \"/etc\", echo \"/var\"")
+  ;; run interactive command, which will create local binding of EXEC-PATH and add to it
+  (add-node-modules-path)
+  ;; checks
+  (should (eq (local-variable-p 'exec-path) t))
+  (should (equal (car exec-path) "/etc"))
+  (should (equal (cadr exec-path) "/var"))
+  ;; env cleanup
+  (kill-local-variable 'add-node-modules-path-debug)
+  (kill-local-variable 'add-node-modules-path-command))
+  
+(ert-deftest add-node-modules-path-multiple-commands-with-failures-test ()
+  ;; remove any local binding of EXEC-PATH, if present
+  (kill-local-variable 'exec-path)
+  ;; prepare environment
+  (make-local-variable 'add-node-modules-path-debug)
+  (setq add-node-modules-path-debug nil)
+  (make-local-variable 'add-node-modules-path-command)
+  (setq add-node-modules-path-command "ls -al, echo \"/var\", date, echo \"/etc\", clear")
+  ;; run interactive command, which will create local binding of EXEC-PATH and add to it
+  (add-node-modules-path)
+  ;; checks
+  (should (eq (local-variable-p 'exec-path) t))
+  (should (equal (car exec-path) "/var"))
+  (should (equal (cadr exec-path) "/etc"))
+  ;; env cleanup
+  (kill-local-variable 'add-node-modules-path-debug)
+  (kill-local-variable 'add-node-modules-path-command))

--- a/test/add-node-modules-path-test.el
+++ b/test/add-node-modules-path-test.el
@@ -57,55 +57,31 @@
     (dolist (elt test-data)
       (should (equal (add-node-modules-path/get-invalid-executions (car elt)) (cadr elt))))))
 
+(defun add-node-modules-path/exec-add-node-modules-path-test (command additions)
+  ;; remove any local binding of EXEC-PATH, if present
+  (kill-local-variable 'exec-path)
+  ;; prepare environment
+  (make-local-variable 'add-node-modules-path-debug)
+  (setq add-node-modules-path-debug nil)
+  (make-local-variable 'add-node-modules-path-command)
+  (setq add-node-modules-path-command command)
+  ;; run interactive command, which will create local binding of EXEC-PATH and add to it
+  (add-node-modules-path)
+  ;; checks
+  (should (eq (local-variable-p 'exec-path) t))
+  (let ((i 0))
+    (dolist (elt additions)
+      (should (equal (nth i exec-path) elt))
+      (setq i (1+ i))))
+  ;; env cleanup
+  (kill-local-variable 'add-node-modules-path-debug)
+  (kill-local-variable 'add-node-modules-path-command))
+
 (ert-deftest add-node-modules-path-single-command-test ()
-  ;; remove any local binding of EXEC-PATH, if present
-  (kill-local-variable 'exec-path)
-  ;; prepare environment
-  (make-local-variable 'add-node-modules-path-debug)
-  (setq add-node-modules-path-debug nil)
-  (make-local-variable 'add-node-modules-path-command)
-  (setq add-node-modules-path-command "echo \"/etc\"")
-  ;; run interactive command, which will create local binding of EXEC-PATH and add to it
-  (add-node-modules-path)
-  ;; checks
-  (should (eq (local-variable-p 'exec-path) t))
-  (should (equal (car exec-path) "/etc"))
-  ;; env cleanup
-  (kill-local-variable 'add-node-modules-path-debug)
-  (kill-local-variable 'add-node-modules-path-command))
-  
+  (add-node-modules-path/exec-add-node-modules-path-test "echo \"/etc\"" '("/etc")))
+
 (ert-deftest add-node-modules-path-multiple-commands-test ()
-  ;; remove any local binding of EXEC-PATH, if present
-  (kill-local-variable 'exec-path)
-  ;; prepare environment
-  (make-local-variable 'add-node-modules-path-debug)
-  (setq add-node-modules-path-debug nil)
-  (make-local-variable 'add-node-modules-path-command)
-  (setq add-node-modules-path-command "echo \"/etc\", echo \"/var\"")
-  ;; run interactive command, which will create local binding of EXEC-PATH and add to it
-  (add-node-modules-path)
-  ;; checks
-  (should (eq (local-variable-p 'exec-path) t))
-  (should (equal (car exec-path) "/etc"))
-  (should (equal (cadr exec-path) "/var"))
-  ;; env cleanup
-  (kill-local-variable 'add-node-modules-path-debug)
-  (kill-local-variable 'add-node-modules-path-command))
+  (add-node-modules-path/exec-add-node-modules-path-test "echo \"/etc\", echo \"/var\"" '("/etc" "/var")))
   
 (ert-deftest add-node-modules-path-multiple-commands-with-failures-test ()
-  ;; remove any local binding of EXEC-PATH, if present
-  (kill-local-variable 'exec-path)
-  ;; prepare environment
-  (make-local-variable 'add-node-modules-path-debug)
-  (setq add-node-modules-path-debug nil)
-  (make-local-variable 'add-node-modules-path-command)
-  (setq add-node-modules-path-command "ls -al, echo \"/var\", date, echo \"/etc\", clear")
-  ;; run interactive command, which will create local binding of EXEC-PATH and add to it
-  (add-node-modules-path)
-  ;; checks
-  (should (eq (local-variable-p 'exec-path) t))
-  (should (equal (car exec-path) "/var"))
-  (should (equal (cadr exec-path) "/etc"))
-  ;; env cleanup
-  (kill-local-variable 'add-node-modules-path-debug)
-  (kill-local-variable 'add-node-modules-path-command))
+  (add-node-modules-path/exec-add-node-modules-path-test "ls -al, echo \"/var\", date, echo \"/etc\", clear" '("/var" "/etc")))

--- a/test/add-node-modules-path-test.el
+++ b/test/add-node-modules-path-test.el
@@ -2,15 +2,15 @@
 ;;
 ;;
 
-(ert-deftest add-node-modules-path/split-comma-separated-list-test ()
-  (should (equal (add-node-modules-path/split-comma-separated-list "pnpm bin, pnpm bin -w,  ls -al   ")
+(ert-deftest add-node-modules-path/trim-list-and-elements-test ()
+  (should (equal (add-node-modules-path/trim-list-and-elements '("pnpm bin" "pnpm bin -w" "ls -al   "))
 		 '("pnpm bin" "pnpm bin -w" "ls -al")))
-  (should (equal (add-node-modules-path/split-comma-separated-list "  pnpm bin -w") '("pnpm bin -w")))
-  (should (equal (add-node-modules-path/split-comma-separated-list ",,, ls -al ,  ,,") '("ls -al")))
-  (should (eq (add-node-modules-path/split-comma-separated-list "") nil))
-  (should (eq (add-node-modules-path/split-comma-separated-list "    ") nil))
-  (should (eq (add-node-modules-path/split-comma-separated-list "   ,  ,,  ,") nil)))
-
+  (should (equal (add-node-modules-path/trim-list-and-elements '("  pnpm bin -w")) '("pnpm bin -w")))
+  (should (equal (add-node-modules-path/trim-list-and-elements '(nil "" " ls -al " "" nil "" nil)) '("ls -al")))
+  (should (eq (add-node-modules-path/trim-list-and-elements "") nil))
+  (should (eq (add-node-modules-path/trim-list-and-elements "    ") nil))
+  (should (eq (add-node-modules-path/trim-list-and-elements 1701) nil))
+  (should (eq (add-node-modules-path/trim-list-and-elements "a string") nil)))
 
 (ert-deftest add-node-modules-path/exec-command-test ()
   (should (eq (add-node-modules-path/exec-command nil) nil))
@@ -78,10 +78,10 @@
   (kill-local-variable 'add-node-modules-path-command))
 
 (ert-deftest add-node-modules-path-single-command-test ()
-  (add-node-modules-path/exec-add-node-modules-path-test "echo \"/etc\"" '("/etc")))
+  (add-node-modules-path/exec-add-node-modules-path-test '("echo \"/usr\"") '("/usr")))
 
 (ert-deftest add-node-modules-path-multiple-commands-test ()
-  (add-node-modules-path/exec-add-node-modules-path-test "echo \"/etc\", echo \"/var\"" '("/etc" "/var")))
+  (add-node-modules-path/exec-add-node-modules-path-test '("echo \"/etc\"" "echo \"/var\"") '("/etc" "/var")))
   
 (ert-deftest add-node-modules-path-multiple-commands-with-failures-test ()
-  (add-node-modules-path/exec-add-node-modules-path-test "ls -al, echo \"/var\", date, echo \"/etc\", clear" '("/var" "/etc")))
+  (add-node-modules-path/exec-add-node-modules-path-test '("ls -al" "echo \"/var\"" "date" "echo \"/etc\"" "clear") '("/var" "/etc")))

--- a/test/add-node-modules-path-test.el
+++ b/test/add-node-modules-path-test.el
@@ -1,0 +1,58 @@
+;;
+;;
+;;
+
+(ert-deftest add-node-modules-path/split-comma-separated-list-test ()
+  (should (equal (add-node-modules-path/split-comma-separated-list "pnpm bin, pnpm bin -w,  ls -al   ")
+		 '("pnpm bin" "pnpm bin -w" "ls -al")))
+  (should (equal (add-node-modules-path/split-comma-separated-list "  pnpm bin -w") '("pnpm bin -w")))
+  (should (equal (add-node-modules-path/split-comma-separated-list ",,, ls -al ,  ,,") '("ls -al")))
+  (should (eq (add-node-modules-path/split-comma-separated-list "") nil))
+  (should (eq (add-node-modules-path/split-comma-separated-list "    ") nil))
+  (should (eq (add-node-modules-path/split-comma-separated-list "   ,  ,,  ,") nil)))
+
+
+(ert-deftest add-node-modules-path/exec-command-test ()
+  (should (eq (add-node-modules-path/exec-command nil) nil))
+  (should (eq (add-node-modules-path/exec-command "") nil))
+  (should (eq (add-node-modules-path/exec-command 3) nil))
+  (should (eq (add-node-modules-path/exec-command 'a-symbol) nil))
+  (if (equal system-type 'gnu/linux)
+      (let ((res (add-node-modules-path/exec-command "echo \"/usr/bin\"")))
+	(should (equal (plist-get res 'command) "echo \"/usr/bin\""))
+	(should (equal (plist-get res 'result) "/usr/bin"))
+	(should (equal (plist-get res 'directory-p) t))))
+  (if (equal system-type 'gnu/linux)
+      (let ((res (add-node-modules-path/exec-command "echo \"ls -al\"")))
+	(should (equal (plist-get res 'command) "echo \"ls -al\""))
+	(should (equal (plist-get res 'result) "ls -al"))
+	(should (equal (plist-get res 'directory-p) nil)))))
+
+(ert-deftest add-node-modules-path/exec-command-list-test ()
+  (let ((should-produce-nil '(nil () 42 "a string" (1 2 3))))
+    (dolist (elt should-produce-nil)
+      (should (eq (add-node-modules-path/exec-command-list elt) nil)))))
+
+(ert-deftest add-node-modules-path/get-valid-directories-test ()
+  (let ((should-produce-nil '(nil () 1 "str" (1 2 3) (('directory-p nil) ('directory-p nil))))
+	(test-data '(
+		     (((directory-p t result "/usr/bin")) ("/usr/bin"))
+		     (((directory-p t result "/home") (directory-p t result "/usr")) ("/home" "/usr"))
+		     (((directory-p nil result "/not-a-valid-dir") (directory-p t result "/usr")) ("/usr"))
+		     )))
+    (dolist (elt should-produce-nil)
+      (should (eq (add-node-modules-path/get-valid-directories elt) nil)))
+    (dolist (elt test-data)
+      (should (equal (add-node-modules-path/get-valid-directories (car elt)) (cadr elt))))))
+
+(ert-deftest add-node-modules-path/get-invalid-executions-test ()
+  (let ((should-produce-nil '(nil () 1 "str" (('directory-p t) ('directory-p t))))
+	(test-data '(
+		     (((directory-p nil result "/usr/bin")) ((directory-p nil result "/usr/bin")))
+		     (((directory-p t result "/home") (directory-p nil result "/usr")) ((directory-p nil result "/usr")))
+		     (((directory-p nil result "/xxx") (directory-p t result "/usr")) ((directory-p nil result "/xxx")))
+		     )))
+    (dolist (elt should-produce-nil)
+      (should (eq (add-node-modules-path/get-invalid-executions elt) nil)))
+    (dolist (elt test-data)
+      (should (equal (add-node-modules-path/get-invalid-executions (car elt)) (cadr elt))))))


### PR DESCRIPTION
Hi!
A few days ago, when I was trying to use a monorepo, I encountered the problem that in your repo was already mentioned and documented as issue #20.

I found the idea of recursively searching node_modules/.bin directories a bit wild. Forty's idea of allowing a list of commands albeit quite sexy.

I took the liberty of sending you a PR that implements this function. It looks like a lot of code, but it's just a bunch of helper functions and the proper remodeling of the add-node-modules-path interactive function.
Additionally a short paragraph in the README.md as well as ert tests.

Of course, the implementation is backwards compatible; it is still possible to use the default value of add-node-modules-path-command or override it with a single command.

Due to the fact that with several commands some commands can work well, but others don't, I had to adjust the reporting. Directories that could be added to exec-path are reported using (message ...). Commands that failed are reported as warnings in the *Warnings* buffer.

Maybe you are interested in the extension. otherwise just ignore :)

best regards from austria,
Max