### PR TITLE
`npm bin` was removed in npm 9.0.0.

### DIFF
--- a/add-node-modules-path.el
+++ b/add-node-modules-path.el
@@ -38,7 +38,7 @@
   :group 'environment)
 
 ;;;###autoload
-(defcustom add-node-modules-path-command "npm bin"
+(defcustom add-node-modules-path-command "npm prefix"
   "Command to find the bin path."
   :type 'string)
 
@@ -54,7 +54,7 @@
 If `npm` command fails, it does nothing."
   (interactive)
 
-  (let* ((res (s-chomp (shell-command-to-string add-node-modules-path-command)))
+  (let* ((res (concat (s-chomp (shell-command-to-string add-node-modules-path-command)) "/node_modules/.bin"))
          (exists (file-exists-p res))
          )
     (cond


### PR DESCRIPTION
Since `npm bin` is no longer available, `npm prefix` is used instead to determine the project root, and from there _assume_ that binaries have been installed into `node_modules/.bin`.  `npm exec` is the recommended replacement for `npm bin`, but - as far as I can tell from poking around - it provides only the ability to run commands and doesn't not have the "discovery" feature of `npm bin`.

I'd be happy to take any guidance on how to generalise this, and not make hardcoded assumptions about `node_modules/.bin`.

See: https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/